### PR TITLE
Basic EME

### DIFF
--- a/example.html
+++ b/example.html
@@ -66,5 +66,26 @@
     <!--<source src="http://eu1.eastmark.net/pdash/testpic_6s/ManifestController.mpd" type='application/dash+xml'>-->
     <!--<source src="http://b028.wpc.azureedge.net/80B028/SampleStream/49be9c8c-0317-470f-94a2-7472732dc844/2cfaa74d-196a-4125-9c22-b84cbe4e9df9.ism/ManifestController(format=mpd-time-csf)" type='application/dash+xml'>-->
 </video>
+<script>
+  var player = videojs('vid1');
+
+  // if "mediakeymessage" is triggered, the video is encrypted and
+  // requires a license
+  player.on('mediakeymessage', function(event) {
+
+    // make a request to the example license server
+    var xhr = new XMLHttpRequest();
+    xhr.responseType = 'arraybuffer';
+    xhr.open('POST', 'http://widevine-proxy.appspot.com/proxy');
+    xhr.onreadystatechange = function() {
+      if (this.readyState === 4) {
+
+        // supply the license to the active media key session
+        return event.mediaKeySession.update(new Uint8Array(this.response));
+      }
+    };
+    xhr.send(event.message);
+  });
+</script>
 </body>
 </html>

--- a/src/js/MediaTypeLoader.js
+++ b/src/js/MediaTypeLoader.js
@@ -117,7 +117,7 @@ MediaTypeLoader.prototype.eventList = {
     DOWNLOAD_DATA_UPDATE: 'downloadDataUpdate'
 };
 
-MediaTypeLoader.prototype.getMediaType = function() { return this.getMediaSet().getMediaType(); };
+MediaTypeLoader.prototype.getMediaType = function() { return this.__mediaType; };
 
 MediaTypeLoader.prototype.getMediaSet = function() { return this.__manifestController.getMediaSetByType(this.__mediaType); };
 

--- a/src/js/SourceHandler.js
+++ b/src/js/SourceHandler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var MediaSource = require('global/window').MediaSource,
+    Decrypter = require('./decrypter'),
     ManifestController = require('./manifest/ManifestController.js'),
     PlaylistLoader = require('./PlaylistLoader.js');
 
@@ -16,7 +17,8 @@ var MediaSource = require('global/window').MediaSource,
  */
 function SourceHandler(source, tech) {
     var self = this,
-        manifestController = new ManifestController(source.src, false);
+        manifestController = new ManifestController(source.src, false),
+        decrypter = new Decrypter(tech);
 
     manifestController.one(manifestController.eventList.MANIFEST_LOADED, function(event) {
         var mediaSource = new MediaSource(),

--- a/src/js/dash/segments/getSegmentListForRepresentation.js
+++ b/src/js/dash/segments/getSegmentListForRepresentation.js
@@ -91,8 +91,21 @@ getTimeShiftBufferDepth = function(representation) {
 };
 
 getSegmentDurationFromTemplate = function(representation) {
-    var segmentTemplate = representation.getSegmentTemplate();
-    return Number(segmentTemplate.getDuration()) / Number(segmentTemplate.getTimescale());
+    var segmentTemplate = representation.getSegmentTemplate(),
+        duration = +segmentTemplate.getDuration(),
+        timescale = +segmentTemplate.getTimescale(),
+        segments,
+        durations;
+
+    if (!duration) {
+        segments = segmentTemplate.xml[0].querySelectorAll('S[d]');
+        durations = Array.prototype.map.call(segments, function(segment) {
+            return +segment.getAttribute('d');
+        });
+        duration = Math.max.apply(null, durations);
+    }
+
+    return duration / timescale;
 };
 
 getTotalSegmentCountFromTemplate = function(representation) {
@@ -131,7 +144,7 @@ createSegmentListFromTemplate = function(representationXml) {
                     initializationRelativeUrl = segmentTemplate.replaceIDForTemplate(initializationRelativeUrlTemplate, representationId);
 
                 initializationRelativeUrl = segmentTemplate.replaceTokenForTemplate(initializationRelativeUrl, 'Bandwidth', representationXml.getBandwidth());
-                return baseUrl + initializationRelativeUrl;
+                return [baseUrl, initializationRelativeUrl].join('/');
             };
             return initialization;
         },
@@ -154,7 +167,7 @@ createSegmentFromTemplateByNumber = function(representation, number) {
         replacedTokensUrl = segmentTemplate.replaceTokenForTemplate(replacedIdUrl, 'Number', number);
         replacedTokensUrl = segmentTemplate.replaceTokenForTemplate(replacedTokensUrl, 'Bandwidth', representation.getBandwidth());
 
-        return baseUrl + replacedTokensUrl;
+      return [baseUrl, replacedTokensUrl].join('/');
     };
     segment.getStartTime = function() {
         return (number - getStartNumberFromTemplate(representation)) * getSegmentDurationFromTemplate(representation);

--- a/src/js/decrypter.js
+++ b/src/js/decrypter.js
@@ -1,31 +1,156 @@
 'use strict';
 
-module.exports = function Decrypter(player, video) {
-  var requestKey;
+var videojs = require('global/window').videojs,
+    MediaKeys,
+    MediaKeySession,
+
+    // widevine is the only implemented CDM in EME v0.1b
+    // future EME recommends key systems are specified ahead of
+    // loading media
+    KEY_SYSTEM = 'com.widevine.alpha';
+
+// ---------
+// Decrypter
+// ---------
+
+module.exports = function Decrypter(tech) {
+  var player = tech.player(),
+      video =  tech.el(),
+      requestKey, createKeySession, session;
 
   requestKey = function(event) {
-    var keySystem = event.keySystem || 'com.widevine.alpha';
-    if (!video.canPlayType(player.currentType(), keySystem)) {
+    if (!(event.keySystem === '' || event.keySystem === KEY_SYSTEM) ||
+        !video.canPlayType('video/mp4', KEY_SYSTEM)) {
       return player.error({
         // MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
         // use the constant to avoid conflicts with monkey-patchers
         code: 4,
-        message: 'Unsupported key system'
+        message: 'Unsupported key system: "' + event.keySystem + '"'
       });
     }
 
+    // create a session to track data related to this set of CDM
+    // interactions
+    session = player.mediaKeys().createSession('temporary', event);
+
     // Request keys from the CDM. The keys are sent to the license
     // server to validate this player's license request.
-    video.webkitGenerateKeyRequest(keySystem, event.initData);
+    // https://w3c.github.io/encrypted-media/initdata-format-registry.html
+    session.generateRequest('cenc', event.initData);
   };
 
-  // setup EME 0.1b event handlers
+  createKeySession = function(event) {
+    if (!event.message) {
+      return player.error({
+        // MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+        // use the constant to avoid conflicts with monkey-patchers
+        code: 4,
+        message: 'Key request generated an invalid response'
+      });
+    }
+    player.trigger({
+      type: 'mediakeymessage',
+      originalEvent: event,
+      message: event.message,
+      mediaKeySession: session
+    });
+  };
+
+  // setup EME v0.1b event handlers
   // see https://dvcs.w3.org/hg/html-media/raw-file/eme-v0.1b/encrypted-media/encrypted-media.html
   if ('onwebkitneedkey' in video) {
     video.addEventListener('webkitneedkey', requestKey);
+    video.addEventListener('webkitkeymessage', createKeySession);
   } else if ('onneedkey' in video) {
     video.addEventListener('needkey', requestKey);
+    video.addEventListener('keymessage', createKeySession);
   } else {
     throw new Error('No compatible content protection system detected');
   }
+};
+
+// -------------
+// EME Emulation
+// -------------
+
+/**
+ * The MediaKeys object represents a set of keys that an associated
+ * HTMLMediaElement can use for decryption of media data during
+ * playback. It also represents a CDM instance.
+ * https://w3c.github.io/encrypted-media/#idl-def-MediaKeys
+ */
+MediaKeys = function MediaKeys(player) {
+  this.activeMediaKeySessions_ = [];
+  this.player_ = player;
+};
+MediaKeys.prototype = new videojs.EventEmitter();
+MediaKeys.prototype.activeMediaKeySessions = function() {
+  return this.activeMediaKeySessions_;
+};
+
+/**
+ * Returns a new MediaKeySession object.
+ * @param type {string}
+ * @see https://w3c.github.io/encrypted-media/#widl-MediaKeys-createSession-MediaKeySession-MediaKeySessionType-sessionType
+ */
+MediaKeys.prototype.createSession = function(type, options) {
+  var video = this.player_.el().querySelector('.vjs-tech'),
+      keySession = new MediaKeySession(video, options);
+  this.activeMediaKeySessions().push(keySession);
+  return keySession;
+};
+
+/**
+ * A Media Key Session, or simply Session, provides a context for
+ * message exchange with the CDM as a result of which key(s) are made
+ * available to the CDM. Sessions are embodied as MediaKeySession
+ * objects. Each Key session is associated with a single instance of
+ * Initialization Data provided in the generateRequest() call.
+ * @see https://w3c.github.io/encrypted-media/#idl-def-MediaKeySession
+ */
+MediaKeySession = function MediaKeySession(video, options) {
+  this.video_ = video;
+  this.sessionId_ = options.sessionId;
+};
+MediaKeySession.prototype = new videojs.EventEmitter();
+
+/**
+ * Generates a request based on the initData.
+ * @param initDataType {string} a string that indicates what format
+ * the initialization data is provided in.
+ * @param initData {BufferSource} a block of initialization data
+ * containing information about the stream to be decrypted
+ * @see https://w3c.github.io/encrypted-media/#widl-MediaKeySession-generateRequest-Promise-void--DOMString-initDataType-BufferSource-initData
+ */
+MediaKeySession.prototype.generateRequest = function(initDataType, initData) {
+  // expose sessionId, step 9.9
+  this.sessionId = this.sessionId_;
+  // trigger a message event, step 9.11
+  this.video_.webkitGenerateKeyRequest(KEY_SYSTEM, initData);
+};
+
+/**
+ * Provides messages, including licenses, to the CDM.
+ * @param response {BufferSource} A message to be provided to the
+ * CDM. The contents are Key System-specific. It must not contain
+ * executable code.
+ * @return {Promise<void>}
+ * @see https://w3c.github.io/encrypted-media/#widl-MediaKeySession-update-Promise-void--BufferSource-response
+ */
+MediaKeySession.prototype.update = function(buffer) {
+  this.video_.webkitAddKey(KEY_SYSTEM, buffer, this.sessionId);
+};
+
+// -----------------
+// Player Extensions
+// -----------------
+
+/**
+ * The MediaKeys being used when decrypting encrypted media data for
+ * this media element.
+ * @see https://w3c.github.io/encrypted-media/#widl-HTMLMediaElement-mediaKeys
+ */
+videojs.Player.prototype.mediaKeys = function() {
+  this.mediaKeys_ = this.mediaKeys_ || new MediaKeys(this);
+  return this.mediaKeys_;
 };

--- a/src/js/decrypter.js
+++ b/src/js/decrypter.js
@@ -1,10 +1,31 @@
 'use strict';
 
 module.exports = function Decrypter(player, video) {
-  var requestKey = function() {
+  var requestKey;
 
+  requestKey = function(event) {
+    var keySystem = event.keySystem || 'com.widevine.alpha';
+    if (!video.canPlayType(player.currentType(), keySystem)) {
+      return player.error({
+        // MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
+        // use the constant to avoid conflicts with monkey-patchers
+        code: 4,
+        message: 'Unsupported key system'
+      });
+    }
+
+    // Request keys from the CDM. The keys are sent to the license
+    // server to validate this player's license request.
+    video.webkitGenerateKeyRequest(keySystem, event.initData);
   };
 
-  video.addEventListener('webkitneedkey', requestKey);
-  video.addEventListener('needkey', requestKey);
+  // setup EME 0.1b event handlers
+  // see https://dvcs.w3.org/hg/html-media/raw-file/eme-v0.1b/encrypted-media/encrypted-media.html
+  if ('onwebkitneedkey' in video) {
+    video.addEventListener('webkitneedkey', requestKey);
+  } else if ('onneedkey' in video) {
+    video.addEventListener('needkey', requestKey);
+  } else {
+    throw new Error('No compatible content protection system detected');
+  }
 };

--- a/test/ManifestController.test.js
+++ b/test/ManifestController.test.js
@@ -173,11 +173,11 @@ QUnit.test('successful static type MPD load updates properties based on XML', fu
         var mediaSets = manifestController.getMediaSets(),
             videoMediaSet = manifestController.getMediaSetByType('video'),
             audioMediaSet = manifestController.getMediaSetByType('audio');
-        assert.strictEqual(mediaSets.length, 2, '');
-        assert.strictEqual(videoMediaSet.getMediaType(), 'video', '');
-        assert.strictEqual(audioMediaSet.getMediaType(), 'audio', '');
-        assert.strictEqual(videoMediaSet.getMimeType(), 'video/mp4', '');
-        assert.strictEqual(audioMediaSet.getMimeType(), 'audio/mp4', '');
+      assert.strictEqual(mediaSets.length, 2, '', 'parsed two media sets');
+        assert.strictEqual(videoMediaSet.getMediaType(), 'video', 'parsed a video media set');
+        assert.strictEqual(audioMediaSet.getMediaType(), 'audio', 'parsed an audio media set');
+        assert.strictEqual(videoMediaSet.getMimeType(), 'video/mp4', 'set the video mime type');
+        assert.strictEqual(audioMediaSet.getMimeType(), 'audio/mp4', 'set the audio mime type');
         done();
     });
 

--- a/test/decrypter.test.js
+++ b/test/decrypter.test.js
@@ -66,17 +66,14 @@ Q.test('errors if an unsupported key system is detected', function() {
 });
 
 Q.test('throws early if used in a browser without EME support', function() {
-  try {
+  Q.throws(function() {
     new Decrypter({
       player: Function.prototype,
       el: function() {
         return {};
       }
     });
-  } catch (e) {
-    return Q.ok(e, 'threw an error on construction');
-  }
-  Q.ok(false, 'threw an error on construction');
+  }, 'threw an error on construction');
 });
 
 Q.test('requests keys', function() {

--- a/test/decrypter.test.js
+++ b/test/decrypter.test.js
@@ -1,5 +1,89 @@
 'use strict';
-var loadManifest = require('../src/js/decrypter.js'),
-    Q = QUnit;
 
-Q.module('Decrypter');
+var Decrypter = require('../src/js/decrypter.js'),
+    videojs = window.videojs,
+    Q = QUnit,
+    player,
+    video,
+    decrypter;
+
+Q.module('Decrypter', {
+  setup: function() {
+    video = Object.create(new videojs.EventEmitter());
+    video.onneedkey = null;
+    video.onwebkitneedkey = null;
+    video.canPlayType = function() {
+      return true;
+    };
+    player = Object.create(new videojs.EventEmitter());
+    player.currentType = function() {
+      return 'video/mp4';
+    };
+    player.error = function(event) {
+      event.type = 'error';
+      return player.trigger.call(player, event);
+    };
+    decrypter = new Decrypter(player, video);
+  }
+});
+
+Q.test('errors if an unsupported key system is detected', function() {
+  var errors = [];
+  player.on('error', function(event) {
+    errors.push(event);
+  });
+  video.canPlayType = function() {
+    return false;
+  };
+  video.webkitGenerateKeyRequest = function() {
+    errors.push('should not request keys when an error occurs');
+  };
+  video.trigger('webkitneedkey', {
+    keySystem: 'unsupported key system'
+  });
+
+  Q.equal(errors.length, 1, 'triggered an error');
+  Q.equal(errors[0].code,
+          window.MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED,
+          'type is SRC_NOT_SUPPORTED');
+});
+
+Q.test('throws early if used in a browser without EME support', function() {
+  delete video.onneedkey;
+  delete video.onwebkitneedkey;
+  try {
+    new Decrypter(player, video);
+  } catch (e) {
+    return Q.ok(e, 'threw an error on construction');
+  }
+  Q.ok(false, 'threw an error on construction');
+});
+
+Q.test('requests keys', function() {
+  var keySystem, initData;
+  video.webkitGenerateKeyRequest = function(ksystem, data) {
+    keySystem = ksystem;
+    initData = data;
+  };
+  video.trigger({
+    type: 'webkitneedkey',
+    keySystem: 'com.widevine.alpha',
+    initData: new Uint8Array([1, 2, 3])
+  });
+
+  Q.equal(keySystem, 'com.widevine.alpha', 'passed along the key system');
+  Q.deepEqual(initData, new Uint8Array([1, 2, 3]), 'passed along init data');
+});
+
+Q.test('assumes the widevine key system when it is unspecified', function() {
+  var keySystem;
+  video.webkitGenerateKeyRequest = function(ksystem) {
+    keySystem = ksystem;
+  };
+  video.trigger({
+    type: 'webkitneedkey',
+    keySystem: ''
+  });
+
+  Q.equal(keySystem, 'com.widevine.alpha', 'inferred widevine');
+});

--- a/test/fixtures/car.mpd
+++ b/test/fixtures/car.mpd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MPD xmlns="urn:mpeg:DASH:schema:MPD:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd" minBufferTime="PT2S" type="dynamic" profiles="urn:mpeg:dash:profile:isoff-live:2011" availabilityStartTime="2014-09-19T00:54:13" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
+<MPD xmlns="urn:mpeg:DASH:schema:MPD:2011" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd" minBufferTime="PT2S" type="static" profiles="urn:mpeg:dash:profile:isoff-live:2011" availabilityStartTime="2014-09-19T00:54:13" minimumUpdatePeriod="PT5S" timeShiftBufferDepth="PT1800S">
   <BaseURL>http://storage.googleapis.com/gtv-videos-bucket/dash/CarWidevine</BaseURL>
   <Period start="PT0S">
     <AdaptationSet id="0">


### PR DESCRIPTION
Listen for EME v0.1b events on the video element and handle a very basic authorization flow. The license server communication is expected to be handled by EME implementors. An example of what that would look like is provided in example.html.

The decryption code emulates the API of the current version of the EME spec. When the updated spec is released into the stable version of Chrome, we can rip out the emulation and just use the native APIs directly.
